### PR TITLE
Check_config, library paths with spaces fix

### DIFF
--- a/prt.py
+++ b/prt.py
@@ -535,7 +535,7 @@ def check_config():
             for path in paths:
                 printf("  Path: '%s'\n", path)
                 proc = subprocess.Popen(["ssh", "%s@%s" % (server["user"], address),
-                    "-p", server["port"], "stat", "--printf='%U %a'", path],
+                    "-p", server["port"], "stat", "--printf='%U %a'", "'" + path "'"],
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 proc.wait()
 

--- a/prt.py
+++ b/prt.py
@@ -535,7 +535,7 @@ def check_config():
             for path in paths:
                 printf("  Path: '%s'\n", path)
                 proc = subprocess.Popen(["ssh", "%s@%s" % (server["user"], address),
-                    "-p", server["port"], "stat", "--printf='%U %a'", "'" + path "'"],
+                    "-p", server["port"], "stat", "--printf='%U %a'", pipes.quote(path)],
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 proc.wait()
 


### PR DESCRIPTION
Fix check_config command for share paths which have spaces.

Expected behaviour:
Host 192.168.2.203
  Connect: OK
  Path: '/media/nfs/Media/Anime'
    User:  nobody
    Mode:  777
    WARN:  Not owned by plex user
  Path: '/media/nfs/Media/Documentaries'
    User:  nobody
    Mode:  777
    WARN:  Not owned by plex user
  Path: '/media/nfs/Media/HD Movies'
    User:  UNKNOWN
    Mode:  777
    WARN:  Not owned by plex user
  Path: '/media/nfs/Media/Tv'
    User:  UNKNOWN
    Mode:  777
    WARN:  Not owned by plex user
  Path: '/usr/lib/plexmediaserver/'
    User:  root
    Mode:  755
    WARN:  Not owned by plex user
  Path: '/opt/plex/tmp'
    User:  plex
    Mode:  755

Actual behaviour:
Host 192.168.2.203
  Connect: OK
  Path: '/media/nfs/Media/Anime'
    User:  nobody
    Mode:  777
    WARN:  Not owned by plex user
  Path: '/media/nfs/Media/Documentaries'
    User:  nobody
    Mode:  777
    WARN:  Not owned by plex user
  Path: '/media/nfs/Media/HD Movies'
Traceback (most recent call last):
  File "/usr/local/bin/prt", line 9, in <module>
    load_entry_point('prt==0.4.1', 'console_scripts', 'prt')()
  File "build/bdist.linux-x86_64/egg/prt.py", line 684, in main
  File "build/bdist.linux-x86_64/egg/prt.py", line 542, in check_config
