### PR TITLE
EAE local transcoding workaround, change logdir

### DIFF
--- a/prt.py
+++ b/prt.py
@@ -67,7 +67,7 @@ DEFAULT_CONFIG = {
                 "class": "logging.handlers.RotatingFileHandler",
                 "level": "INFO",
                 "formatter": "simple",
-                "filename": "/tmp/prt.log",
+                "filename": "/opt/plex/tmp/prt.log",
                 "maxBytes": 10485760,
                 "backupCount": 20,
                 "encoding": "utf8"
@@ -319,14 +319,6 @@ def transcode_remote():
 
     config = get_config()
     args   = sys.argv[1:]
-
-
-    # FIX: This is (temporary?) fix for the EasyAudioEncoder (EAE) which uses a
-    #      hardcoded path in /tmp.  If we find that EAE is being used then we
-    #      force transcoding on the master
-    if 'eae_prefix' in ' '.join(args):
-        log.info("Found EAE is being used...forcing local transcode")
-        return transcode_local()
 
     # Check to see if we need to call a user-script to replace/modify the file path
     if config.get("path_script", None):


### PR DESCRIPTION
Discovered that plexmediaserver will fall back to using the transcode directory if it gets a `Permission Denied` error when writing to `/tmp/pms-*/` at service startup:
```
<TRANSCODE_DIR>/Transcode/Sessions/EasyAudioEncoder
```

To take advantage of this, the `plex` user needs to have write access to `/tmp` removed. This can be accomplished with:
```
setfacl -m u:plex:r /tmp/
```

With `/tmp` unable to be written to by the `plex` user, the default config for logging filename needs to be somewhere the `plex` user has write access (this uses `/opt/plex/tmp/prt.log`, matching the shared transcode directory in the wiki).

I have this working with Ubuntu 18.04 x64 master/slaves and PMS `1.13.9.5439-7303bc002` with EAE transcodes being executed on any host (including remote slaves).