### PR TITLE
Import plex token

### DIFF
--- a/prt.py
+++ b/prt.py
@@ -63,7 +63,7 @@ def get_auth_token():
         plex_auth_token = prefs.attrib['PlexOnlineToken']
 
         if not plex_auth_token:
-            print "Couldn't find PlexOnlineToken in settings file - %S. Make sure your Plex Server is setup correctly.", SETTINGS_PATH
+            print "Couldn't find PlexOnlineToken in settings file - %s. Make sure your Plex Server is setup correctly.", SETTINGS_PATH
             print "Obtaining Plex auth token from plex.tv..."
 
             # Fallback to prompting for Plex username/password
@@ -89,6 +89,12 @@ def get_auth_token():
 
             data = json.load(res)
             return data['user']['authToken']
+        else:
+            print "Using Plex auth token from settings file - %s.", SETTINGS_PATH
+
+    except KeyError, e:
+        printf("ERROR: PlexOnlineToken not found in settings file - %s" , SETTINGS_PATH, color="red")
+        return False
 
     except Exception, e:
         printf("ERROR: Couldn't open settings file - %s", SETTINGS_PATH, color="red")

--- a/prt.py
+++ b/prt.py
@@ -642,6 +642,7 @@ def usage():
         "  overwrite             Fix PRT after PMS has had a version update breaking PRT\n" 
         "  add_host              Add an extra host to the list of slaves PRT is to use\n" 
         "  remove_host           Removes a host from the list of slaves PRT is to use\n"
+        "  auth_token            Add Plex auth token to configuration\n"
         "  sessions              Display current sessions\n"
         "  check_config          Checks the current configuration for errors\n")
 
@@ -674,16 +675,16 @@ def main():
     elif sys.argv[1] == "install":
         print "Installing Plex Remote Transcoder"
         config = get_config()
-
-        if raw_input("Add Plex auth token? [y/n]").lower() == "y":
-            config["auth_token"] = get_auth_token()
-            if config["auth_token"] is None:
-                print "Unable to add Plex auth token... Check prt.log"
-
         config["ipaddress"] = raw_input("IP address of this machine: ")
         save_config(config)
 
         install_transcoder()
+
+    elif sys.argv[1] == "auth_token":
+        print "Adding Plex auth token"
+        config = get_config()
+        config["auth_token"] = get_auth_token()
+        save_config(config)
 
     elif sys.argv[1] == "add_host":
         host = None

--- a/prt.py
+++ b/prt.py
@@ -60,46 +60,43 @@ def get_auth_token():
     try:
         # Look for token in plexmediaserver SETTINGS_PATH file
         prefs = ET.parse(SETTINGS_PATH).getroot()
-        plex_auth_token = prefs.attrib['PlexOnlineToken']
-
-        if not plex_auth_token:
-            print "Couldn't find PlexOnlineToken in settings file - %s. Make sure your Plex Server is setup correctly.", SETTINGS_PATH
-            print "Obtaining Plex auth token from plex.tv..."
-
-            # Fallback to prompting for Plex username/password
-            url = "https://plex.tv/users/sign_in.json"
-            payload = urllib.urlencode({
-                "user[login]": raw_input("Plex Username: "),
-                "user[password]": getpass.getpass("Plex Password: "),
-                "X-Plex-Client-Identifier": "Plex-Remote-Transcoder-v%s" % __version__,
-                "X-Plex-Product": "Plex-Remote-Transcoder",
-                "X-Plex-Version": __version__
-            })
-            req = urllib2.Request(url, payload)
-
-            try:
-                res = urllib2.urlopen(req)
-            except:
-                print "Error getting auth token...invalid credentials?"
-                return False
-
-            if res.code not in [200, 201]:
-                print "Invalid credentials"
-                return False
-
-            data = json.load(res)
-            return data['user']['authToken']
-        else:
-            print "Using Plex auth token from settings file - %s." % SETTINGS_PATH
+        prefs_token = prefs.attrib['PlexOnlineToken']
 
     except KeyError, e:
-        printf("ERROR: PlexOnlineToken not found in settings file - %s", SETTINGS_PATH, color="red")
-        return False
+        print "Couldn't find PlexOnlineToken in settings file - %s." % SETTINGS_PATH
+        print "Obtaining Plex auth token from plex.tv..."
+
+        # Fallback to prompting for Plex username/password
+        url = "https://plex.tv/users/sign_in.json"
+        payload = urllib.urlencode({
+            "user[login]": raw_input("Plex Username: "),
+            "user[password]": getpass.getpass("Plex Password: "),
+            "X-Plex-Client-Identifier": "Plex-Remote-Transcoder-v%s" % __version__,
+            "X-Plex-Product": "Plex-Remote-Transcoder",
+            "X-Plex-Version": __version__
+        })
+        req = urllib2.Request(url, payload)
+
+        try:
+            res = urllib2.urlopen(req)
+        except:
+            print "Error getting auth token...invalid credentials?"
+            return False
+
+        if res.code not in [200, 201]:
+            print "Invalid credentials"
+            return False
+
+        data = json.load(res)
+        print "Using Plex auth token obtained from plex.tv"
+        return data['user']['authToken']
 
     except Exception, e:
         printf("ERROR: Couldn't open settings file - %s", SETTINGS_PATH, color="red")
         return False
-    return plex_auth_token
+
+    print "Using Plex auth token from settings file - %s." % SETTINGS_PATH
+    return prefs_token
 
 
 DEFAULT_CONFIG = {

--- a/prt.py
+++ b/prt.py
@@ -90,10 +90,10 @@ def get_auth_token():
             data = json.load(res)
             return data['user']['authToken']
         else:
-            print "Using Plex auth token from settings file - %s.", SETTINGS_PATH
+            print "Using Plex auth token from settings file - %s." % SETTINGS_PATH
 
     except KeyError, e:
-        printf("ERROR: PlexOnlineToken not found in settings file - %s" , SETTINGS_PATH, color="red")
+        printf("ERROR: PlexOnlineToken not found in settings file - %s", SETTINGS_PATH, color="red")
         return False
 
     except Exception, e:


### PR DESCRIPTION
Updates `get_auth_token()` to pull in existing Plex auth token from the `SETTINGS_PATH` file, with a fallback to prompting the user for their Plex creds to obtain a token from `plex.tv`. Also adds `auth_token` argument.