### PR TITLE
Use servers_script when running check_config

### DIFF
--- a/prt.py
+++ b/prt.py
@@ -560,15 +560,16 @@ def check_config():
             proc = subprocess.Popen(config["servers_script"].split(), stdout=subprocess.PIPE)
             proc.wait()
 
-        servers = {}
-        for line in proc.stdout.readlines():
-            hostname, port, user = line.strip().split()
-            servers[hostname] = {
-                "port": port,
-                "user": user
-            }
-    except Exception, e:
-        log.error("Error retreiving host list via '%s': %s" % (config["servers_script"], str(e)))
+            servers = {}
+            for line in proc.stdout.readlines():
+                hostname, port, user = line.strip().split()
+                servers[hostname] = {
+                    "port": port,
+                    "user": user
+                }
+        except Exception, e:
+            log.error("Error retreiving host list via '%s': %s" % (config["servers_script"], str(e)))
+            servers = config["servers"]
 
     # Let's check SSH access
     for address, server in servers.items():

--- a/prt.py
+++ b/prt.py
@@ -362,7 +362,7 @@ def transcode_remote():
     # Look to see if we need to run an external script to get hosts
     if config.get("servers_script", None):
         try:
-            proc = subprocess.Popen([config["servers_script"].split()], stdout=subprocess.PIPE)
+            proc = subprocess.Popen(config["servers_script"].split(), stdout=subprocess.PIPE)
             proc.wait()
 
             servers = {}
@@ -557,7 +557,7 @@ def check_config():
     # Look to see if we need to run an external script to get hosts
     if config.get("servers_script", None):
         try:
-            proc = subprocess.Popen([config["servers_script"].split()], stdout=subprocess.PIPE)
+            proc = subprocess.Popen(config["servers_script"].split(), stdout=subprocess.PIPE)
             proc.wait()
 
         servers = {}

--- a/prt.py
+++ b/prt.py
@@ -362,7 +362,7 @@ def transcode_remote():
     # Look to see if we need to run an external script to get hosts
     if config.get("servers_script", None):
         try:
-            proc = subprocess.Popen([config["servers_script"]], stdout=subprocess.PIPE)
+            proc = subprocess.Popen([config["servers_script"].split()], stdout=subprocess.PIPE)
             proc.wait()
 
             servers = {}
@@ -557,7 +557,7 @@ def check_config():
     # Look to see if we need to run an external script to get hosts
     if config.get("servers_script", None):
         try:
-            proc = subprocess.Popen([config["servers_script"]], stdout=subprocess.PIPE)
+            proc = subprocess.Popen([config["servers_script"].split()], stdout=subprocess.PIPE)
             proc.wait()
 
         servers = {}

--- a/prt.py
+++ b/prt.py
@@ -552,8 +552,26 @@ def check_config():
         7: [settings['TranscoderTempDirectory']]
     }
 
+    servers = config["servers"]
+
+    # Look to see if we need to run an external script to get hosts
+    if config.get("servers_script", None):
+        try:
+            proc = subprocess.Popen([config["servers_script"]], stdout=subprocess.PIPE)
+            proc.wait()
+
+        servers = {}
+        for line in proc.stdout.readlines():
+            hostname, port, user = line.strip().split()
+            servers[hostname] = {
+                "port": port,
+                "user": user
+            }
+    except Exception, e:
+        log.error("Error retreiving host list via '%s': %s" % (config["servers_script"], str(e)))
+
     # Let's check SSH access
-    for address, server in config['servers'].items():
+    for address, server in servers.items():
         printf("Host %s\n", address)
 
         proc = subprocess.Popen(["ssh", "%s@%s" % (server["user"], address),


### PR DESCRIPTION
When running `prt check_config`, it would only verify hosts listed under `servers` in `.prt.conf` (even if `servers_script` is not null). This changes the behavior to match how `prt` decides which host to handle a transcode (use `servers_script` if set, fallback to `servers` in `.prt.conf`).